### PR TITLE
Add `bytemuck` as an optional dependency, allow bytemucking the lottes tonemapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ kolor = { version = "0.1", default-features = false, features = ["f32", "color-m
 thiserror = "1.0"
 derivative = "2.2"
 serde = { version = "1", optional = true, features = ["derive"] }
+bytemuck = { version = "1.5.1", optional = true, features = ["derive"] }
 
 [features]
 default = ["with-serde", "std"]

--- a/src/tonemapper.rs
+++ b/src/tonemapper.rs
@@ -44,7 +44,7 @@ impl Default for LottesTonemaperParams {
 
 /// See this talk by Timothy Lottes https://gpuopen.com/wp-content/uploads/2016/03/GdcVdrLottes.pdf and associated slides
 /// https://gpuopen.com/wp-content/uploads/2016/03/GdcVdrLottes.pdf
-#[cfg_attr(feature = "bytemuck", repr(C))]
+#[repr(C)]
 #[cfg_attr(feature = "bytemuck", derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable))]
 pub struct LottesTonemapper {
     a: f32,

--- a/src/tonemapper.rs
+++ b/src/tonemapper.rs
@@ -44,6 +44,8 @@ impl Default for LottesTonemaperParams {
 
 /// See this talk by Timothy Lottes https://gpuopen.com/wp-content/uploads/2016/03/GdcVdrLottes.pdf and associated slides
 /// https://gpuopen.com/wp-content/uploads/2016/03/GdcVdrLottes.pdf
+#[cfg_attr(feature = "bytemuck", repr(C))]
+#[cfg_attr(feature = "bytemuck", derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable))]
 pub struct LottesTonemapper {
     a: f32,
     b: f32,


### PR DESCRIPTION
This makes it really easy to use the tonemapper in a shader by serializing it into a push constant.