### PR TITLE
fix docs & examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,14 @@
 //! in the Rust type system (as with the strongly-typed [`Color`]),
 //! or as data contained in the type (as with the dynamically-typed [`DynamicColor`]).
 //!
-//! Although it is designed to prevent footguns wherever possible, in order to make use of this library,
-//! you should have a well-working understanding of basic color science and encoding principles.
-//! As such, I highly recommend you give sections 2.0 and 2.1 of this document a read, as it is one
-//! of the main inspirations for how this library is structured:
+//! Although it is designed to prevent footguns wherever possible, in order to make use of this
+//! library, you should have a well-working understanding of basic color science and encoding
+//! principles. As such, I highly recommend you give sections 2.0 and 2.1 [of this document](#res1)
+//! a read, as it is one of the main inspirations for how this library is structured:
 //!
-//! All colors in Ark will now be accompanied either statically or dynamically with two important pieces
-//! of metadata, a **color space** and a **state**. A basic background on color encoding is necessary to
-//! understand what these pieces of metadata are and why they are important.
+//! All colors in Ark will now be accompanied either statically or dynamically with two important
+//! pieces of metadata, a **color space** and a **state**. A basic background on color encoding is
+//! necessary to understand what these pieces of metadata are and why they are important.
 //!
 //! ## Color Encoding Basics
 //!
@@ -22,36 +22,47 @@
 //!
 //! * The motion vector of an object in meters per second
 //! * The position of an object relative to a reference point in kilometers
-//! * Three "wellness scores" for a character, which each axis representing how happy the charcter is about some aspect of their life
+//! * Three "wellness scores" for a character, which each axis representing how happy the character
+//!   is about some aspect of their life
 //!
-//! A bag of components that describes "a color" could actually be interpreted in many different ways, and the end result of what
-//! those components mean is very different. There are two important pieces of metadata about a color which inform how we are meant
-//! to interpret its component values: the color's **Color Space** and its **State**.
+//! A bag of components that describes "a color" could actually be interpreted in many different
+//! ways, and the end result of what those components mean is very different. There are two
+//! important pieces of metadata about a color which inform how we are meant to interpret its
+//! component values: the color's **Color Space** and its **State**.
 //!
 //! ### Color Spaces
 //!
-//! A "color space" is a fairly nebulous term which has different definitions depending on who you talk to, but the basic idea is that
-//! it provides a specific organization of color data in an agreed-upon format. The color space provides almost all the information needed
-//! to fully interpret the component data. However, it is missing one important piece of metadata which is relevant when working with rendered
-//! scenes that may have higher dynamic range within the scene than an actual display is capable of displaying (a computer monitor cannot replicate
-//! the brightness of the sun, but within the renderer, we want to actually simulate those high brightnesses). That is where the color state comes in.
+//! A "color space" is a fairly nebulous term which has different definitions depending on who you
+//! talk to, but the basic idea is that it provides a specific organization of color data in an
+//! agreed-upon format. The color space provides almost all the information needed to fully
+//! interpret the component data. However, it is missing one important piece of metadata which is
+//! relevant when working with rendered scenes that may have higher dynamic range within the scene
+//! than an actual display is capable of displaying (a computer monitor cannot replicate the
+//! brightness of the sun, but within the renderer, we want to actually simulate those high
+//! brightnesses). That is where the color state comes in.  
 //!
 //! ### Color State
 //!
-//! As we have discussed, all colors have units. Sometimes a color’s units are explicit, such as measuring the emitted light from a display using a
-//! radiometric measurement tool and being able to reference pixel values in a color space built for that. Other times, the units are only indirectly
-//! related to the real world, but come with a mathematical conversion to measurable quantities. For example, in the case of display technology, common
-//! color encodings include sRGB, DCI-P3, and BT.2020, which are all standards which actual monitors attempt to replicate.
+//! As we have discussed, all colors have units. Sometimes a color’s units are explicit, such as
+//! measuring the emitted light from a display using a radiometric measurement tool and being able
+//! to reference pixel values in a color space built for that. Other times, the units are only
+//! indirectly related to the real world, but come with a mathematical conversion to measurable
+//! quantities. For example, in the case of display technology, common color encodings include
+//! sRGB, DCI-P3, and BT.2020, which are all standards which actual monitors attempt to replicate.
 //!
-//! However, considering color as a displayed quantity only provides part of the color encoding story. In addition to relating color values to
-//! **display measurements**, as we did above, one can also relate color values to the performance characteristics of an **input device** (i.e., a
-//! camera, or in our case, a virtual camera in a 3d renderer). In this case, we are quantifying color values which originated in the (virtual) **scene**,
-//! rather than ones being displayed on a display. This kind of color can be measured in real world units as well. In the case of a 3d renderer, these units
-//! are often defined in the renderer as a photometric quantity like luminance, with the relation to reference color values dictated by a defined transformation.
+//! However, considering color as a displayed quantity only provides part of the color encoding
+//! story. In addition to relating color values to **display measurements**, as we did above, one
+//! can also relate color values to the performance characteristics of an **input device** (i.e., a
+//! camera, or in our case, a virtual camera in a 3d renderer). In this case, we are quantifying
+//! color values which originated in the (virtual) **scene**, rather than ones being displayed on a
+//! display. This kind of color can be measured in real world units as well. In the case of a 3d
+//! renderer, these units are often defined in the renderer as a photometric quantity like
+//! luminance, with the relation to reference color values dictated by a defined transformation.
 //!
-//! It is a meaningful abstraction to categorize colors based on this distinction of *input* versus *output* reference. We refer to this
-//! difference as a color's **State**. Colors which are defined in relation to *display characteristic* are called **Display-referred**, while
-//! color spaces which are defined in relation to *input devices* (scenes) are **Scene-referred**.
+//! It is a meaningful abstraction to categorize colors based on this distinction of *input* versus
+//! *output* reference. We refer to this difference as a color's **State**. Colors which are
+//! defined in relation to *display characteristic* are called **Display-referred**, while color
+//! spaces which are defined in relation to *input devices* (scenes) are **Scene-referred**.
 //!
 //! # Overview
 //!
@@ -61,23 +72,24 @@
 //! and deserializing colors and otherwise interacting with colors from dynamic sources not
 //! known at compile time.
 //!
-//! The core of the statically-typed half is the [`Color`] type, which encodes
-//! two important pieces of metadata about the color in its type signature (`Color<Space, State>`): the
-//! color's **color space** and **state**. If you read the color encoding basics above (you did, didn't you? ;) )
-//! then you should have a decent idea of what both of these things mean. To be clear, the **color space**
-//! encodes the **primaries**, **white point**, and **transfer functions** upon which the color values are
-//! based. The **state** encodes in which "direction" we relate the color values to real-world quantities:
-//! either **scene-referred** or **display-referred**. Types which implement the [`ColorSpace`] and
-//! [`State`] traits encode this information statically. Color spaces can be found in the `spaces` module
-//! and states can be found in the `states` module.
+//! The core of the statically-typed half is the [`Color`] type, which encodes two important pieces
+//! of metadata about the color in its type signature (`Color<Space, State>`): the color's **color
+//! space** and **state**. If you read the color encoding basics above (you did, didn't you? ;) )
+//! then you should have a decent idea of what both of these things mean. To be clear, the **color
+//! space** encodes the **primaries**, **white point**, and **transfer functions** upon which the
+//! color values are based. The **state** encodes in which "direction" we relate the color values
+//! to real-world quantities: either **scene-referred** or **display-referred**. Types which
+//! implement the [`ColorSpace`] and [`State`] traits encode this information statically. Color
+//! spaces can be found in the [`spaces`] module and states can be found in the [`states`] module.
 //!
-//! The core of the dynamically-typed half is the [`DynamicColor`] type, which encodes the color space
-//! and state as data stored in the type at runtime. It stores these as [`DynamicColorSpace`]s and [`DynamicState`]s.
+//! The core of the dynamically-typed half is the [`DynamicColor`] type, which encodes the color
+//! space and state as data stored in the type at runtime. It stores these as
+//! [`DynamicColorSpace`]s and [`DynamicState`]s.
 //!
 //! # Example
 //!
-//! Let's say we have a color that we got from an asset loaded from a color image or a color picker,
-//! which are often in the encoded sRGB color space.
+//! Let's say we have a color that we got from an asset loaded from a color image or a color
+//! picker, which are often in the encoded sRGB color space.
 //!
 //! ```rust
 //! # use colstodian::*;
@@ -92,14 +104,14 @@
 //! let my_other_color = loaded_asset_color * 5.0; // oops, compile error!
 //! ```
 //!
-//! This color is encoded in a non-linear format. You can think of this much like
-//! as if a file was compressed as a ZIP. Doing operations directly on the zipped
-//! bytes is nonsensical. First we need to decode it to work on the raw data.
-//! In the same way, before we can do math on this color, we need to convert it to a working color space.
+//! This color is encoded in a non-linear format. You can think of this much like as if a file was
+//! compressed as a ZIP. Doing operations directly on the zipped bytes is nonsensical. First we
+//! need to decode it to work on the raw data. In the same way, before we can do math on this
+//! color, we need to convert it to a working color space.  
 //!
-//! Encoded color spaces all have a working color space that they can decode to directly. This will be the
-//! least expensive and most natural conversion if you want to work with them directly. For example,
-//! an [EncodedSrgb] color will decode to a [LinearSrgb] color:
+//! Encoded color spaces all have a working color space that they can decode to directly. This
+//! will be the least expensive and most natural conversion if you want to work with them directly.
+//! For example, an [EncodedSrgb] color will decode to a [LinearSrgb] color:
 //!
 //! ```rust
 //! # use colstodian::*;
@@ -123,11 +135,11 @@
 //! let blended = oklab1.blend(oklab2, 0.5); // Blend half way between the two colors
 //! ```
 //!
-//! This is also the first time we see the [`convert`][Color::convert] method, which we'll be using,
-//! along with its sibling [`convert_to`][Color::convert_to],
-//! to do most of our conversions. You can use this to do pretty much any conversion you like, so long
-//! as you stay within the same [State]. See the docs of that method for more information. Generally, you'll
-//! want to convert the color to some output color space before actually using it. It's quite common to use
+//! This is also the first time we see the [`convert`][Color::convert] method, which we'll be
+//! using, along with its sibling [`convert_to`][Color::convert_to], to do most of our conversions.
+//! You can use this to do pretty much any conversion you like, so long as you stay within the same
+//! [State]. See the docs of that method for more information. Generally, you'll want to convert
+//! the color to some output color space before actually using it. It's quite common to use
 //! [EncodedSrgb] for this purpose. This is also quite simple with `convert`:
 //!
 //! ```rust
@@ -149,9 +161,9 @@
 //! ```
 //!
 //! Here we can see an example of where [`convert_to`][Color::convert_to] may be preferrable over
-//! [`convert`][Color::convert]. Notice how we are using the type [`Color<EncodedSrgb, Display>`] quite
-//! often? You might want to create a type alias for this type called, for example, `Asset`. Wouldn't it
-//! be convenient to also be able to `convert` to a type alias of [`Color`]? Well, with
+//! [`convert`][Color::convert]. Notice how we are using the type [`Color<EncodedSrgb, Display>`]
+//! quite often? You might want to create a type alias for this type called, for example, `Asset`.
+//! Wouldn't it be convenient to also be able to `convert` to a type alias of [`Color`]? Well, with
 //! [`convert_to`][Color::convert_to], you can! This is particularly useful when you don't want to
 //! bind the output to a variable directly, so you can't take advantage of type inference and
 //! need to use the turbofish operator. For example, let's rewrite the previous blending example:
@@ -202,14 +214,14 @@
 //! # use colstodian::*;
 //! let col: Color<ICtCpPQ, Display> = Color::new(1.0, 0.2, 0.2);
 //!
-//! let intensity = col.i; // acces I (Intensity) component through .i
+//! let intensity = col.i; // access I (Intensity) component through .i
 //! let ct = col.ct; // access Ct (Chroma-Tritan) component through .ct
 //! let cp = col.cp; // access Cp (Chroma-Protan) component through .cp
 //! ```
 //!
 //! One more quite useful tool is the [`ColorInto`] trait. [`ColorInto`] is
 //! a trait meant to be used as a replacement for [`Into`] in situations where you want
-//! to bound a type as being able to be converted into a specific type of color. A you can
+//! to bound a type as being able to be converted into a specific type of color. You can
 //! call [`.into`][ColorInto::into] on a type that implements [`ColorInto<T>`]
 //! and you will get a `T`.
 //!
@@ -223,7 +235,7 @@
 //!     color * tint
 //! }
 //!
-//! let color = color::srgb_u8(225, 200, 86);
+//! let color = color::srgb_u8(225, 200, 86).to_f32();
 //! let tinted: Color<EncodedSrgb, Display> = tint_color(color).convert();
 //!
 //! println!("Pre-tint: {}, Post-tint: {}", color, tinted);
@@ -233,13 +245,13 @@
 //!
 //! Let's say that instead of blending perceptually between colors, we are creating a 3d rendering
 //! engine. In this case, we probably want to do the actual shading math in a color space with a
-//! wider (sharper) gamut (the reasons for this are outside the scope of this demo). The [ACEScg][AcesCg]
-//! space is ideal for this.
+//! wider (sharper) gamut (the reasons for this are outside the scope of this demo). The
+//! [ACEScg][AcesCg] space is ideal for this.
 //!
 //! Since both color spaces are linear, the ideally optimized transformation is a simple
-//! 3x3 matrix * 3 component vector multiplication. `colstodian` is architected such that we can still
-//! just use the [`convert`][Color::convert] method to convert between these spaces and it will
-//! indeed optimize fully down to just that multiplication.
+//! 3x3 matrix * 3 component vector multiplication. `colstodian` is architected such that we can
+//! still just use the [`convert`][Color::convert] method to convert between these spaces and it
+//! will indeed optimize fully down to just that multiplication.
 //!
 //! ```rust
 //! # use colstodian::*;
@@ -247,19 +259,21 @@
 //! let col: Color<AcesCg, Display> = decoded.convert();
 //! ```
 //!
-//! Now, we come to a bit of a subtle operation. Here we will convert the color from being in a display-reffered
-//! state to being in a scene-referred state. This operation is not necessarily concrete, and is dependent on
-//! the thing you are converting. Going from display-referred to scene-referred, we are converting from a
-//! bounded dynamic range with physical reference units for the color component values being
-//! (with a properly calibrated monitor) the **display standard specification**,
-//! to an unbounded dynamic range, with color components in the range `[0..inf)` and the physical reference units
-//! for these component values being the units used in the **scene,** which are defined by the renderer itself.
-//! In most cases, these units will be in a measurement of photometric luminance like [Cd/m^2 aka nits](https://en.wikipedia.org/wiki/Candela_per_square_metre).
+//! Now, we come to a bit of a subtle operation. Here we will convert the color from being in a
+//! display-reffered state to being in a scene-referred state. This operation is not necessarily
+//! concrete, and is dependent on the thing you are converting. Going from display-referred to
+//! scene-referred, we are converting from a bounded dynamic range with physical reference units
+//! for the color component values being (with a properly calibrated monitor) the **display
+//! standard specification**, to an unbounded dynamic range, with color components in the range
+//! `[0..inf)` and the physical reference units for these component values being the units used in
+//! the **scene,** which are defined by the renderer itself. In most cases, these units will be in
+//! a measurement of photometric luminance like
+//! [Cd/m^2 aka nits](https://en.wikipedia.org/wiki/Candela_per_square_metre).
 //!
-//! One possible use of this conversion is the case of an emissive texture, where we may want to modify the bounded
-//! [illuminance (i.e. lux)](https://en.wikipedia.org/wiki/Illuminance) of the color we stored in the texture by some
-//! unbounded *power* value stored elsewhere. In this way, we can make emissive materials just as powerful as any other
-//! light in the scene.
+//! One possible use of this conversion is the case of an emissive texture, where we may want to
+//! modify the bounded [illuminance (i.e. lux)](https://en.wikipedia.org/wiki/Illuminance) of the
+//! color we stored in the texture by some unbounded *power* value stored elsewhere. In this way,
+//! we can make emissive materials just as powerful as any other light in the scene.
 //!
 //! ```rust
 //! # use colstodian::*;
@@ -276,9 +290,9 @@
 //! // ... rendering math here ...
 //! ```
 //!
-//! Okay, so let's say we've ended up with a final color for a pixel, which is still scene-referred in the
-//! ACEScg color space, representing the luminance reaching the camera from a specific direction (namely, the direction
-//! corresponding to the pixel we are shading).
+//! Okay, so let's say we've ended up with a final color for a pixel, which is still scene-referred
+//! in the ACEScg color space, representing the luminance reaching the camera from a specific
+//! direction (namely, the direction corresponding to the pixel we are shading).
 //!
 //! ```rust
 //! # use colstodian::*;
@@ -286,9 +300,10 @@
 //! ```
 //!
 //! Now we need to do the opposite of what we did before and map the infinite dynamic range of a
-//! scene-referred color outputted by the renderer to the finite dynamic range which can be displayed
-//! on a display. For an output display which is "SDR" (i.e. not an HDR-enabled TV or monitor), a fairly
-//! aggressive S-curve style tonemap is a good option. We provide a couple of options in the [`tonemap`] module.
+//! scene-referred color outputted by the renderer to the finite dynamic range which can be
+//! displayed on a display. For an output display which is "SDR" (i.e. not an HDR-enabled TV or
+//! monitor), a fairly aggressive S-curve style tonemap is a good option. We provide a couple of
+//! options in the [`tonemap`] module.
 //!
 //! ```rust
 //! # use colstodian::*;
@@ -300,10 +315,10 @@
 //! let tonemapped: Color<AcesCg, Display> = PerceptualTonemapper::tonemap(rendered_col, params).convert();
 //! ```
 //!
-//! Now, our color is display-referred within a finite (`[0..1]`) dynamic range. However, we haven't chosen
-//! an actual specific display to encode it for. This is what the sRGB standard can help with, which
-//! is most likely the standard upon which an LDR monitor will be based. We can convert our color to
-//! [encoded sRGB][EncodedSrgb] just like we showed before.
+//! Now, our color is display-referred within a finite (`[0..1]`) dynamic range. However, we
+//! haven't chosen an actual specific display to encode it for. This is what the sRGB standard can
+//! help with, which is most likely the standard upon which an LDR monitor will be based. We can
+//! convert our color to [encoded sRGB][EncodedSrgb] just like we showed before.
 //!
 //! ```rust
 //! # use colstodian::*;
@@ -311,11 +326,11 @@
 //! let encoded = tonemapped.convert::<EncodedSrgb>(); // Ready to display or write to an image.
 //!
 //! // Again, if your output format needs `u8`s (say, an 8-bit PNG image), you can use the `to_u8()` method.
-//! let u8s: [u8; 3] = encoded.to_u8();
+//! let u8s: [u8; 3] = encoded.to_u8().raw;
 //! ```
 //!
-//! Alternatively, we could output to a different display, for example to a wide-gamut but still LDR
-//! BT.2020 calibrated display:
+//! Alternatively, we could output to a different display, for example to a wide-gamut but still
+//! LDR BT.2020 calibrated display:
 //!
 //! ```rust
 //! # use colstodian::*;
@@ -323,26 +338,33 @@
 //! let encoded = tonemapped.convert::<EncodedBt2020>();
 //! ```
 //!
-//! This doesn't cover displaying to an HDR display yet, nor the use of colors with an alpha channel, but it soon will!
+//! This doesn't cover displaying to an HDR display yet, nor the use of colors with an alpha
+//! channel, but it soon will!
 //!
 //! # Further Resources
 //!
-//! Here is a curated list of further resources to check out for information about color encoding and management.
+//! Here is a curated list of further resources to check out for information about color encoding
+//! and management:
 //!
-//! * An overview of color management from a cinematic perspective (HIGHLY recommend sections 2.0 and 2.1): <http://github.com/jeremyselan/cinematiccolor/raw/master/ves/Cinematic_Color_VES.pdf>
-//! * The Hitchhiker's Guide to Digital Color: <https://hg2dc.com/>
-//! * Alex Fry (DICE/Frostbite) on HDR color management in Frostbite: <https://www.youtube.com/watch?v=7z_EIjNG0pQ>
-//! * Timothy Lottes (AMD) on "variable" dynamic range color management: <https://www.gdcvault.com/play/1023512/Advanced-Graphics-Techniques-Tutorial-Day>
-//! * Hajime Uchimura and Kentaro Suzuki on HDR and Wide color strategies in Gran Turismo SPORT: <https://www.polyphony.co.jp/publications/sa2018/>
+//! 1. <span id="res1">An overview of color management from a cinematic perspective</span>
+//!    (HIGHLY recommended sections 2.0 and 2.1):<br/>
+//!    <http://github.com/jeremyselan/cinematiccolor/raw/master/ves/Cinematic_Color_VES.pdf>
+//! 2. The Hitchhiker's Guide to Digital Color:<br/> <https://hg2dc.com/>
+//! 3. Alex Fry (DICE/Frostbite) on HDR color management in Frostbite:<br/>
+//!    <https://www.youtube.com/watch?v=7z_EIjNG0pQ>
+//! 4. Timothy Lottes (AMD) on "variable" dynamic range color management:<br/>
+//!    <https://www.gdcvault.com/play/1023512/Advanced-Graphics-Techniques-Tutorial-Day>
+//! 5. Hajime Uchimura and Kentaro Suzuki on HDR and Wide color strategies in Gran Turismo SPORT:
+//!    <br/> <https://www.polyphony.co.jp/publications/sa2018/>
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use kolor;
 
 /// Types representing different color spaces.
 ///
-/// For more information, see the documentation for the corresponding
-/// dynamic color space (you can figure out the corresponding dynamic color space by looking at the)
-/// implementation of the [`ColorSpace`] trait on a specific color space struct.
+/// For more information, see the documentation for the corresponding dynamic color space (you can figure out the
+/// corresponding dynamic color space by looking at the implementation of the [`ColorSpace`] trait on a specific
+/// color space struct).
 #[rustfmt::skip]
 pub mod spaces;
 #[doc(inline)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -40,8 +40,8 @@ pub trait EncodedColorSpace: ColorSpace {
     type DecodedSpace: WorkingColorSpace + ConvertFromRaw<Self>;
 }
 
-/// Marks a type as representing a color space that is not [encoded][EncodedColorSpace] and is therefore
-/// able to have many more operations performed on it.
+/// Marks a type as representing a color space that is not [encoded][EncodedColorSpace] and is
+/// therefore able to have many more operations performed on it.
 pub trait WorkingColorSpace: ColorSpace {}
 
 /// Performs the raw conversion from the [`ColorSpace`] represented by `SrcSpc` to
@@ -86,8 +86,9 @@ impl<SrcSpace: ColorSpace, DstSpace: ConvertFromRaw<SrcSpace>> ConvertToRaw<DstS
 
 /// A trait meant to be used as a replacement for [`Into`] in situations where you want
 /// to bound a type as being able to be converted into a specific type of color.
-/// Because of how `colstodian` works and how [`From`]/[`Into`] are implemented, we can't use them directly
-/// for this purpose.
+///
+/// Because of how `colstodian` works and how [`From`]/[`Into`] are implemented, we can't use them
+/// directly for this purpose.
 ///
 /// # Example
 ///
@@ -100,7 +101,7 @@ impl<SrcSpace: ColorSpace, DstSpace: ConvertFromRaw<SrcSpace>> ConvertToRaw<DstS
 ///     color * tint
 /// }
 ///
-/// let color = color::srgb_u8(225, 200, 86);
+/// let color = color::srgb_u8(225, 200, 86).to_f32();
 /// let tinted: Color<EncodedSrgb, Display> = tint_color(color).convert();
 ///
 /// println!("Pre-tint: {}, Post-tint: {}", color, tinted);
@@ -116,23 +117,31 @@ pub trait AsU8 {}
 /// A type that implements this trait represents a color's State.
 ///
 /// All colors have units. Sometimes a color's units are explicit, such as measuring the emitted
-/// light from a display using a spectroradiometer and being able to reference pixel values in CIE XYZ cd/m2.
+/// light from a display using a spectroradiometer and being able to reference pixel values in
+/// CIE XYZ cd/m2.
+///
 /// Other times, the units are only indirectly related to the real world, and then providing a
-/// mathematical conversion to measurable quantities. For example, in the case of display technology, common color encodings
-/// (relations of code value to measurable XYZ performance) include sRGB, DCI-P3, and BT.2020.
+/// mathematical conversion to measurable quantities. For example, in the case of display
+/// technology, common color encodings (relations of code value to measurable XYZ performance)
+/// include sRGB, DCI-P3, and BT.2020.  
 ///
-/// Howver, considering color as a displayed quantity only provides part of the color encoding story. In addition to relating RGB
-/// values to display measurements, one can also relate RGB values to the performance characteristics of an
-/// *input device* (i.e., a camera, or a virtual camera in a 3d renderer). Input colorimetry can be measured in real world units as well.
-/// In the case of a 3d renderer, these units are often (or at least should be) defined in the renderer as a radiometric quantity like
-/// radiance, with the relation to XYZ values dictated by a linear transformation to the rendering color space.
-/// Even in the case of a real world camera, it is not difficult to measure an input spectra with the spectrophotometer
-/// in XYZ, and then compare this to the RGB values output from the camera.
+/// However, considering color as a displayed quantity only provides part of the color encoding
+/// story. In addition to relating RGB values to display measurements, one can also relate RGB
+/// values to the performance characteristics of an *input device* (i.e., a camera, or a virtual
+/// camera in a 3d renderer). Input colorimetry can be measured in real world units as well.
 ///
-/// It is a meaningful abstraction to categorize color spaces by the “direction” of this relationship to real world
-/// quantities, which we refer to as State. Colors which are defined in relation to display
-/// characteristic are called [`Display`][crate::Display]-referred, while color spaces which are defined in relation to input
-/// devices (scenes) are [`Scene`][crate::Scene]-referred.
+/// In the case of a 3d renderer, these units are often (or at least should be) defined in the
+/// renderer as a radiometric quantity like radiance, with the relation to XYZ values dictated by a
+/// linear transformation to the rendering color space.
+///
+/// Even in the case of a real world camera, it is not difficult to measure an input spectra with
+/// the spectrophotometer in XYZ, and then compare this to the RGB values output from the camera.
+///
+/// It is a meaningful abstraction to categorize color spaces by the “direction” of this
+/// relationship to real world quantities, which we refer to as State. Colors which are defined in
+/// relation to display characteristic are called [`Display`][crate::Display]-referred, while color
+/// spaces which are defined in relation to input devices (scenes) are
+/// [`Scene`][crate::Scene]-referred.
 pub trait State: Default {
     const STATE: DynamicState;
 }
@@ -165,8 +174,8 @@ impl<T> ConvertFromAlphaRaw<T> for T {
     }
 }
 
-/// The complement of [`ConvertFromAlphaRaw`]. Performs the conversion from [alpha state][AlphaState] `Self` into `DstAlphaState`
-/// on a raw color.
+/// The complement of [`ConvertFromAlphaRaw`]. Performs the conversion from
+/// [alpha state][AlphaState] `Self` into `DstAlphaState` on a raw color.
 ///
 /// This is automatically implemented for all types that implement [`ConvertFromAlphaRaw`],
 /// much like how the [From] and [Into] traits work, where [From] gets you [Into] for free.
@@ -204,12 +213,14 @@ where
 /// A "conversion query" for a [`ColorAlpha`][crate::ColorAlpha].
 ///
 /// A type that implements this
-/// trait is able to be used as the type parameter for [`ColorAlpha::convert_to`][crate::ColorAlpha::convert_to].
+/// trait is able to be used as the type parameter for
+/// [`ColorAlpha::convert_to`][crate::ColorAlpha::convert_to].
 ///
 /// The types that implement this trait are:
 /// * [`ColorSpace`] types
 /// * [`AlphaState`] types
-/// * [`ColorAlpha`][crate::ColorAlpha] types (in which case it will be converted to that color's space and alpha state)
+/// * [`ColorAlpha`][crate::ColorAlpha] types (in which case it will be converted to that color's
+///   space and alpha state)
 pub trait ColorAlphaConversionQuery<SrcSpace: ColorSpace, SrcAlpha: AlphaState> {
     type DstSpace: ConvertFromRaw<SrcSpace>;
     type DstAlpha: ConvertFromAlphaRaw<SrcAlpha> + AlphaState;
@@ -249,11 +260,12 @@ impl<'a> From<&'a dyn AnyColor> for DynamicColor {
 }
 
 /// A type that implements this trait provides the ability to downcast from a dynamically-typed
-/// color to a statically-typed [`Color`]. This is implemented for all types that implement [`AnyColor`]
+/// color to a statically-typed [`Color`]. This is implemented for all types that implement
+/// [`AnyColor`]
 #[cfg(not(target_arch = "spirv"))]
 pub trait DynColor {
-    /// Attempt to convert to a typed `Color`. Returns an error if `self`'s color space and state do not match
-    /// the given types.
+    /// Attempt to convert to a typed `Color`. Returns an error if `self`'s color space and state
+    /// do not match the given types.
     fn downcast<Spc: ColorSpace, St: State>(&self) -> ColorResult<Color<Spc, St>>;
 
     /// Convert to a typed `Color` without checking if the color space and state types
@@ -276,11 +288,12 @@ pub trait AnyColorAlpha {
 }
 
 /// A type that implements this trait provides the ability to downcast from a dynamically-typed
-/// color to a statically-typed [`ColorAlpha`]. This is implemented for all types that implement [`AnyColorAlpha`]
+/// color to a statically-typed [`ColorAlpha`]. This is implemented for all types that implement
+/// [`AnyColorAlpha`]
 #[cfg(not(target_arch = "spirv"))]
 pub trait DynColorAlpha {
-    /// Attempt to downcast to a typed [`ColorAlpha`]. Returns an error if `self`'s color space and alpha state do not match
-    /// the given types.
+    /// Attempt to downcast to a typed [`ColorAlpha`]. Returns an error if `self`'s color space
+    /// and alpha state do not match the given types.
     fn downcast<Spc: ColorSpace, St: State, A: AlphaState>(&self) -> ColorResult<ColorAlpha<Spc, St, A>>;
 
     /// Downcast to a typed [`ColorAlpha`] without checking if the color space and state types


### PR DESCRIPTION
Hi! first of all thank for creating this wonderful crate. I'm learning to work with color and I'm very happy having found your project, since it has a lot of depth and growth potential, while being simple to use in a way that I like very much.

While I was learning to use it I realized I could help fixing some things: three examples that didn't compile, some typos & links and I also limited the doc line lenghts on a couple of source files to make them easier to be read from the source files. More specifically:

- in `lib.rs`:
  - limit the doc line length.
  - reformat the "further resources" section.
  - add an inner link in the first paragraph to the first resource.
  - change the phrase "all colors in Ark will now be" to "all colors are".
  - add links to `spaces` & `states` modules in "Overview" section.
  - fix typos (*charcter*, *acces*, *A you*).
  - fix doc examples:
    - `encoded.to_u8()` → `encoded.to_u8().raw`.
    - `color::srgb_u8(225, 200, 86)` → `color::srgb_u8(225, 200, 86).to_f32()`.
- in `traits.rs`:
  - fix doc example:
    - `color::srgb_u8(225, 200, 86)` → `color::srgb_u8(225, 200, 86).to_f32()`.
  - limit the doc line length.
  - fix typos (*howver*).

I could've kept going on but I didn't wanted to intrude too much. I hope you like it or at least don't mind my PR, and please feel free to accept or reject it or ask for any changes you want, or anything.