### PR TITLE
Update to latest `kolor`, Rust 2021, badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "colstodian"
 version = "0.1.0-rc.4"
 authors = ["Gray Olson <gray@grayolson.com>"]
 license = "MIT OR Apache-2.0 OR Zlib"
-edition = "2018"
+edition = "2021"
 description = "An opinionated, practical color management library for games and graphics."
 documentation = "https://docs.rs/colstodian"
 homepage = "https://github.com/termhn/colstodian"
@@ -11,18 +11,17 @@ repository = "https://github.com/termhn/colstodian"
 
 [package.metadata.docs.rs]
 features = ["std", "with-serde", "with-bytemuck"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/state/manifest.html
 
 [dependencies]
-# kolor = { version = "^0.1.6", default-features = false, features = ["glam", "f32", "color-matrices"] }
-# kolor = { version = "^0.1.6", default-features = false, features = ["glam", "f32", "color-matrices"], path = "../kolor/build/kolor" }
-kolor = { version = "^0.1.6", default-features = false, features = ["glam", "f32", "color-matrices"], git = "https://github.com/termhn/kolor", rev = "5daf3d8" }
-glam = { version = "0.17", default-features = false } # keep in sync with kolor
+bytemuck = { version = "1.13.1", optional = true }
+cint = { version = "^0.3.1", features = ["bytemuck"] }
+glam = { version = "0.23", default-features = false } # keep in sync with kolor
+# kolor = { version = "^0.1.8", default-features = false, features = ["glam", "f32", "color-matrices"] }
+# kolor = { version = "^0.1.8", default-features = false, features = ["glam", "f32", "color-matrices"], path = "../kolor/build/kolor" }
+kolor = { version = "0.1.9", default-features = false, features = ["glam", "f32", "color-matrices"] }
+num-traits = { version = "0.2", optional = true, default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
-bytemuck = { version = "1.5.1", optional = true }
-num-traits = { version = "^0.2.14", optional = true, default-features = false }
-cint = { version = "^0.2.1", features = ["bytemuck"] }
 
 [features]
 default = ["std", "with-bytemuck"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # `colstodian`
 
-[![crates.io](http://meritbadge.herokuapp.com/colstodian)](https://crates.io/crates/colstodian)
+[![crates.io](https://img.shields.io/crates/v/colstodian.svg)](https://crates.io/crates/colstodian)
 [![docs.rs](https://docs.rs/colstodian/badge.svg)](https://docs.rs/colstodian)
+[![ci](https://github.com/fu5ha/colstodian/actions/workflows/ci.yaml/badge.svg)](https://github.com/fu5ha/colstodian/actions)
 
 ## Introduction
 
 `colstodian` is a practical, opinionated color management library for games and graphics.
+
 For more information, see [the latest docs](https://termhn.github.io/colstodian/colstodian/) built
 from git `main`.
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 */
 
-use glam::{const_vec3, Vec3};
+use glam::Vec3;
 #[cfg(all(not(feature = "std"), feature = "libm"))]
 use num_traits::Float;
 #[cfg(feature = "serde")]
@@ -40,7 +40,7 @@ pub struct Color<Spc, St> {
 #[macro_export]
 macro_rules! const_color {
     ($el1:expr, $el2:expr, $el3:expr) => {
-        Color::from_raw(const_vec3!([$el1, $el2, $el3]))
+        Color::from_raw(Vec3::new([$el1, $el2, $el3]))
     };
 }
 
@@ -59,13 +59,13 @@ impl<Spc, St> AsRef<[f32; 3]> for Color<Spc, St> {
 impl<Spc, St> Color<Spc, St> {
     /// Creates a [`Color`] with the internal color elements `el1`, `el2`, `el3`.
     #[inline]
-    pub fn new(el1: f32, el2: f32, el3: f32) -> Self {
+    pub const fn new(el1: f32, el2: f32, el3: f32) -> Self {
         Self::from_raw(Vec3::new(el1, el2, el3))
     }
 
     /// Creates a [`Color`] with the internal color elements all set to `el`.
     #[inline]
-    pub fn splat(el: f32) -> Self {
+    pub const fn splat(el: f32) -> Self {
         Self::from_raw(Vec3::splat(el))
     }
 
@@ -88,8 +88,8 @@ impl<Spc, St> Color<Spc, St> {
         self.raw.min_element()
     }
 
-    pub const ZERO: Self = const_color!(0.0, 0.0, 0.0);
-    pub const ONE: Self = const_color!(1.0, 1.0, 1.0);
+    pub const ZERO: Self = Color::new(0.0, 0.0, 0.0);
+    pub const ONE: Self = Color::new(1.0, 1.0, 1.0);
 }
 
 impl<Spc: WorkingColorSpace, St> Color<Spc, St> {

--- a/src/color/color_alpha.rs
+++ b/src/color/color_alpha.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 */
 
-use glam::{const_vec4, Vec4, Vec4Swizzles};
+use glam::{Vec4, Vec4Swizzles};
 #[cfg(all(not(feature = "std"), feature = "libm"))]
 use num_traits::Float;
 #[cfg(feature = "serde")]
@@ -36,7 +36,7 @@ pub struct ColorAlpha<Spc, St, A> {
 macro_rules! const_color_alpha {
     ($el1:expr, $el2:expr, $el3:expr, $alpha:expr) => {
         ColorAlpha {
-            raw: const_vec4!([$el1, $el2, $el3, $alpha]),
+            raw: Vec4::new($el1, $el2, $el3, $alpha),
             _pd: PhantomData,
         }
     };
@@ -57,13 +57,13 @@ impl<Spc, St, A> AsRef<[f32; 4]> for ColorAlpha<Spc, St, A> {
 impl<Spc, St, A> ColorAlpha<Spc, St, A> {
     /// Creates a [`ColorAlpha`] with the raw internal color elements `el1`, `el2`, `el3` and alpha value `alpha`.
     #[inline]
-    pub fn new(el1: f32, el2: f32, el3: f32, alpha: f32) -> Self {
+    pub const fn new(el1: f32, el2: f32, el3: f32, alpha: f32) -> Self {
         Self::from_raw(Vec4::new(el1, el2, el3, alpha))
     }
 
     /// Creates a [`ColorAlpha`] with the internal color elements all set to `el`.
     #[inline]
-    pub fn splat(el: f32) -> Self {
+    pub const fn splat(el: f32) -> Self {
         Self::from_raw(Vec4::splat(el))
     }
 


### PR DESCRIPTION
* Updated to latest `kolor` & `glam` (in sync with `kcolor`) and made resp. fixes as `const_*` macros were deprecated in `glam` `v0.22`.
* Updated other deps.
* Updated to Rust 2021.
* Fixed the `crates.io` badge & added a CI badge in the `README`.

See also [this `kolor` PR](https://github.com/BoxDragon/kolor/pull/13).